### PR TITLE
Added GNL_PATH variable to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,18 @@ TIMEOUT_US				= 1000000
 
 .DEFAULT_GOAL			= a
 UTILS					= utils/sigsegv.cpp utils/color.cpp utils/check.cpp utils/gnl.cpp utils/leaks.cpp
+GNL_PATH				= ..
 TESTS_PATH				= tests/
 SHELL					= bash
 
 
-MANDATORY_HEADER		= ../get_next_line.h
-MANDATORY_FILES			= ../get_next_line.c ../get_next_line_utils.c
-MANDATORY_OBJS			= $(MANDATORY_FILES:../%.c=%.o)
+MANDATORY_HEADER		= $(GNL_PATH)/get_next_line.h
+MANDATORY_FILES			= $(GNL_PATH)/get_next_line.c $(GNL_PATH)/get_next_line_utils.c
+MANDATORY_OBJS			= $(MANDATORY_FILES:$(GNL_PATH)/%.c=%.o)
 
-BONUS_HEADER			= ../get_next_line_bonus.h
-BONUS_FILES				= ../get_next_line_bonus.c ../get_next_line_utils_bonus.c
-BONUS_OBJS				= $(BONUS_FILES:../%.c=%.o)
+BONUS_HEADER			= $(GNL_PATH)/get_next_line_bonus.h
+BONUS_FILES				= $(GNL_PATH)/get_next_line_bonus.c $(GNL_PATH)/get_next_line_utils_bonus.c
+BONUS_OBJS				= $(BONUS_FILES:$(GNL_PATH)/%.c=%.o)
 
 MANDATORY				= mandatory
 1MANDATORY				= $(addprefix 1, $(MANDATORY))
@@ -30,7 +31,7 @@ BONUS					= bonus
 10MBONUS				= $(addprefix 10M, $(BONUS))
 
 CFLAGS					= -Wall -Wextra -Werror
-CPPFLAGS				= -g3 -ldl -std=c++11 -I utils/ -I.. -Wno-everything
+CPPFLAGS				= -g3 -ldl -std=c++11 -I utils/ -I$(GNL_PATH) -Wno-everything
 
 UNAME = $(shell uname -s)
 ifeq ($(UNAME), Linux)
@@ -72,7 +73,7 @@ mandatory_start: update
 	@tput setaf 4 && echo [Mandatory]
 
 bonus_start: update
-	tput setaf 3 && printf "[Static = " && cat ../*bonus.c | grep -E 'static.*;' | wc -l | tr -d '\n' | xargs /bin/echo -n && printf "]\n"
+	tput setaf 3 && printf "[Static = " && cat $(GNL_PATH)/*bonus.c | grep -E 'static.*;' | wc -l | tr -d '\n' | xargs /bin/echo -n && printf "]\n"
 	@tput setaf 5 && /bin/echo [Bonus]
 
 update:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gnlTester (2019+)
 Tester for the get next line project of 42 school (with personalized leaks checking on mac, using valgrind on linux)  
 If all your tests are OK and the moulinette KO you, please contact me on slack/discord.  
-Clone this tester in your get_next_line repository. (works on linux and mac, handles sigsegv on all tests, and timeout on mandatory part)  
+Clone this tester in your get_next_line repository, or somewhere else and customize the path to your get_next_line project by changing the GNL_PATH variable inside the Makefile. (works on linux and mac, handles sigsegv on all tests, and timeout on mandatory part)  
 ![alt text](https://i.imgur.com/uupv1UH.png)
 
 


### PR DESCRIPTION
I added a variable called `GNL_PATH` to the Makefile, allowing users to clone this tester on a different path than the project's root. Also, information about it was added to the README.