### PR TITLE
GDB: fix circular dependency on malloc in std::vector

### DIFF
--- a/tests/bonus.cpp
+++ b/tests/bonus.cpp
@@ -15,9 +15,13 @@ extern "C"
 #include "check.hpp"
 #include "gnl.hpp"
 
+//https://github.com/arhuaco/ram-is-mine/blob/master/src/ram_is_mine.c
+extern bool is_initializing;
+
 int iTest = 1;
 int main(void)
 {
+	is_initializing = false;
 	signal(SIGSEGV, sigsegv); int fd[4];
 	title("[BUFFER_SIZE = " << BUFFER_SIZE << "]: " << ENDL)
 	

--- a/tests/mandatory.cpp
+++ b/tests/mandatory.cpp
@@ -15,9 +15,13 @@ extern "C"
 #include "check.hpp"
 #include "gnl.hpp"
 
+//https://github.com/arhuaco/ram-is-mine/blob/master/src/ram_is_mine.c
+extern bool is_initializing;
+
 int iTest = 1;
 int main(void)
 {
+	is_initializing = false;
 	signal(SIGSEGV, sigsegv); int fd;
 	title("[BUFFER_SIZE = " << BUFFER_SIZE << "]: " << ENDL)
 	title("Invalid fd: ")

--- a/utils/color.cpp
+++ b/utils/color.cpp
@@ -1,7 +1,14 @@
 #include "color.hpp"
 
+extern bool is_initializing;
+
 std::ostream &
 operator<<(std::ostream & os, Color c)
 {
-	return os << "\e[" << static_cast<int>(c) << "m";
+	bool old_is_initializing = is_initializing;
+	is_initializing = true;
+	std::basic_ostream<char, std::char_traits<char> > &basicOstream =
+			os << "\e[" << static_cast<int>(c) << "m";
+	is_initializing = old_is_initializing;
+	return basicOstream;
 }

--- a/utils/gnl.hpp
+++ b/utils/gnl.hpp
@@ -3,7 +3,21 @@
 # include "leaks.hpp"
 
 //Don't do that at home
-#define TEST(x) {int status = 0; int test = fork(); if (test == 0) {x showLeaks(); exit(EXIT_SUCCESS);} else {usleep(TIMEOUT_US); if (waitpid(test, &status, WNOHANG) == 0) {kill(test, 9); cout << FG_RED << "TIMEOUT";}}}
+#define TEST(x) { \
+	int status = 0;   \
+	int test = fork();\
+	if (test == 0) { \
+		x               \
+		showLeaks();    \
+		exit(EXIT_SUCCESS); \
+	} else {          \
+		usleep(TIMEOUT_US); \
+		if (waitpid(test, &status, WNOHANG) == 0) { \
+			kill(test, 9); \
+			cout << FG_RED << "TIMEOUT";\
+		}             \
+	}                 \
+}
 
 void gnl(int fd, char const * s);
 


### PR DESCRIPTION
Current implementation prevents running testers under GDB due to circular dependency on malloc in mallocListAdd(p, size) function;

in accordance to 
// https://stackoverflow.com/questions/6083337
//https://github.com/arhuaco/ram-is-mine/blob/master/src/ram_is_mine.c

I have introduced a minor fix for that.

Hope this would be helpful