### PR TITLE
added -gdwarf-4 to all gcc compilations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,34 +38,34 @@ ifeq ($(UNAME), Linux)
 endif
 
 $(1MANDATORY): 1%:
-	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(MANDATORY_FILES)
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(MANDATORY_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(MANDATORY_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 $(42MANDATORY): 42%:
-	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(MANDATORY_FILES)
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(MANDATORY_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(MANDATORY_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 $(10MMANDATORY): 10M%:
-	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(MANDATORY_FILES)
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(MANDATORY_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(MANDATORY_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 
 
 $(1BONUS): 1%:
-	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(BONUS_FILES)
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 $(42BONUS): 42%:
-	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(BONUS_FILES)
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 $(10MBONUS): 10M%:
-	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(BONUS_FILES)
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 
 $(1MBONUS): m1%:
-	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(BONUS_FILES)
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 $(42MBONUS): m42%:
-	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(BONUS_FILES)
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 $(10MMBONUS): m10M%:
-	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(BONUS_FILES)
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
 	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
 
 mandatory_start: update


### PR DESCRIPTION
hi, i'm currently doing the common core in 42 RomaLuiss and i'm using the get_next_line tester but when i run "make m" it gives me this error:

==59471== Valgrind: debuginfo reader: Possibly corrupted debuginfo file.
==59471== Valgrind: I can't recover.  Giving up.  Sorry.

i looked that you added the -gdwarf-4 flag at clang but in this way it doesn't work on my campus pc, so i added it at gcc and now it works perfectly.
anyway beautiful work with your tester, congratulations!