### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 TIMEOUT_US				= 1000000
-
 .DEFAULT_GOAL			= a
 UTILS					= utils/sigsegv.cpp utils/color.cpp utils/check.cpp utils/gnl.cpp utils/leaks.cpp
 TESTS_PATH				= tests/
@@ -9,10 +8,18 @@ SHELL					= bash
 MANDATORY_HEADER		= ../get_next_line.h
 MANDATORY_FILES			= ../get_next_line.c ../get_next_line_utils.c
 MANDATORY_OBJS			= $(MANDATORY_FILES:../%.c=%.o)
+# unique objs per BUFFER_SIZE for mandatory
+M1_OBJS					= get_next_line.bs1.o get_next_line_utils.bs1.o
+M42_OBJS				= get_next_line.bs42.o get_next_line_utils.bs42.o
+M10M_OBJS				= get_next_line.bs10M.o get_next_line_utils.bs10M.o
 
 BONUS_HEADER			= ../get_next_line_bonus.h
 BONUS_FILES				= ../get_next_line_bonus.c ../get_next_line_utils_bonus.c
 BONUS_OBJS				= $(BONUS_FILES:../%.c=%.o)
+# unique objs per BUFFER_SIZE for bonus
+B1_OBJS					= get_next_line_bonus.bs1.o get_next_line_utils_bonus.bs1.o
+B42_OBJS				= get_next_line_bonus.bs42.o get_next_line_utils_bonus.bs42.o
+B10M_OBJS				= get_next_line_bonus.bs10M.o get_next_line_utils_bonus.bs10M.o
 
 MANDATORY				= mandatory
 1MANDATORY				= $(addprefix 1, $(MANDATORY))
@@ -38,35 +45,44 @@ ifeq ($(UNAME), Linux)
 endif
 
 $(1MANDATORY): 1%:
-	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(MANDATORY_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(MANDATORY_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c ../get_next_line.c -o get_next_line.bs1.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c ../get_next_line_utils.c -o get_next_line_utils.bs1.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(M1_OBJS) -o gnlTest_bs1 && $(VALGRIND) ./gnlTest_bs1 < files/alternate_line_nl_with_nl && rm -f gnlTest_bs1
 $(42MANDATORY): 42%:
-	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(MANDATORY_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(MANDATORY_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c ../get_next_line.c -o get_next_line.bs42.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c ../get_next_line_utils.c -o get_next_line_utils.bs42.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(M42_OBJS) -o gnlTest_bs42 && $(VALGRIND) ./gnlTest_bs42 < files/alternate_line_nl_with_nl && rm -f gnlTest_bs42
 $(10MMANDATORY): 10M%:
-	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(MANDATORY_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(MANDATORY_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c ../get_next_line.c -o get_next_line.bs10M.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c ../get_next_line_utils.c -o get_next_line_utils.bs10M.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(M10M_OBJS) -o gnlTest_bs10M && $(VALGRIND) ./gnlTest_bs10M < files/alternate_line_nl_with_nl && rm -f gnlTest_bs10M
 
 
 $(1BONUS): 1%:
-	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c ../get_next_line_bonus.c -o get_next_line_bonus.bs1.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c ../get_next_line_utils_bonus.c -o get_next_line_utils_bonus.bs1.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(B1_OBJS) -o gnlTest_bbs1 && $(VALGRIND) ./gnlTest_bbs1 < files/alternate_line_nl_with_nl && rm -f gnlTest_bbs1
 $(42BONUS): 42%:
-	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c ../get_next_line_bonus.c -o get_next_line_bonus.bs42.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c ../get_next_line_utils_bonus.c -o get_next_line_utils_bonus.bs42.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(B42_OBJS) -o gnlTest_bbs42 && $(VALGRIND) ./gnlTest_bbs42 < files/alternate_line_nl_with_nl && rm -f gnlTest_bbs42
 $(10MBONUS): 10M%:
-	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c ../get_next_line_bonus.c -o get_next_line_bonus.bs10M.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c ../get_next_line_utils_bonus.c -o get_next_line_utils_bonus.bs10M.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$*.cpp $(B10M_OBJS) -o gnlTest_bbs10M && $(VALGRIND) ./gnlTest_bbs10M < files/alternate_line_nl_with_nl && rm -f gnlTest_bbs10M
 
 $(1MBONUS): m1%:
-	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c ../get_next_line_bonus.c -o get_next_line_bonus.bs1.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=1 $(CFLAGS) -c ../get_next_line_utils_bonus.c -o get_next_line_utils_bonus.bs1.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=1 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(B1_OBJS) -o gnlTest_mbs1 && $(VALGRIND) ./gnlTest_mbs1 < files/alternate_line_nl_with_nl && rm -f gnlTest_mbs1
 $(42MBONUS): m42%:
-	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c ../get_next_line_bonus.c -o get_next_line_bonus.bs42.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=42 $(CFLAGS) -c ../get_next_line_utils_bonus.c -o get_next_line_utils_bonus.bs42.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=42 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(B42_OBJS) -o gnlTest_mbs42 && $(VALGRIND) ./gnlTest_mbs42 < files/alternate_line_nl_with_nl && rm -f gnlTest_mbs42
 $(10MMBONUS): m10M%:
-	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c $(BONUS_FILES) -gdwarf-4
-	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(BONUS_OBJS) -o gnlTest && $(VALGRIND) ./gnlTest < files/alternate_line_nl_with_nl && rm -f gnlTest
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c ../get_next_line_bonus.c -o get_next_line_bonus.bs10M.o -gdwarf-4
+	@gcc -D BUFFER_SIZE=10000000 $(CFLAGS) -c ../get_next_line_utils_bonus.c -o get_next_line_utils_bonus.bs10M.o -gdwarf-4
+	@clang++ -D BUFFER_SIZE=10000000 -gdwarf-4 -D TIMEOUT_US=$(TIMEOUT_US) $(CPPFLAGS) $(UTILS) $(TESTS_PATH)$(MANDATORY).cpp $(B10M_OBJS) -o gnlTest_mbs10M && $(VALGRIND) ./gnlTest_mbs10M < files/alternate_line_nl_with_nl && rm -f gnlTest_mbs10M
 
 mandatory_start: update
 	@tput setaf 4 && echo [Mandatory]
@@ -90,6 +106,6 @@ b: bonus_start $(1MBONUS) $(42MBONUS) $(10MMBONUS) $(1BONUS) $(42BONUS) $(10MBON
 a: m b
 
 fclean clean cleanMandatory cleanBonus:
-	@rm -rf $(MANDATORY_OBJS) $(BONUS_OBJS) gnlTest*
+	@rm -rf $(MANDATORY_OBJS) $(BONUS_OBJS) *.o gnlTest*
 
 .PHONY:	mandatory_start m bonus_start b a fclean clean cleanMandatory cleanBonus

--- a/README.md
+++ b/README.md
@@ -3,6 +3,19 @@ Tester for the get next line project of 42 school (with personalized leaks check
 Clone this tester in your get_next_line repository. (works on linux and mac, handles sigsegv on all tests, and timeout on mandatory part)  
 ![alt text](https://i.imgur.com/uupv1UH.png)
 
+# NEW FEATURE!
+Now gnl tester support the job flag of Makefile for faster build *in parallel* (instead of building everything sequentially).
+to use it you just have to do the following command in your terminal :
+
+On linux terminal:
+
+```sh
+  make -j$(nproc) m
+```
+On mac terminal:
+```sh
+   make -j$(sysctl -n hw.ncpu) m
+```
 
 # Commands
 make m = launch mandatory tests  


### PR DESCRIPTION
This patch is here because The Makefile was building several variants (mandatory, 42mandatory, 10Mmandatory, bonus, different BUFFER_SIZE) in parallel and reuses the same .o names/paths. With -j, multiple jobs write get_next_line.o (and friends) at the same time, corrupting objects. That explains:
“error in get_next_line.o(.eh_frame)” and weird symbols.
undefined reference to get_next_line.
runtime SIGILL at ft_memmove (corrupted binary).
-j also triggers bonus targets while bonus files don’t exist, hence the “No such file” errors.

# FIXES
serialize builds: add .NOTPARALLEL at the top of the Makefile (or run make -j1).

Proper: isolate build outputs:
Use per-target/per-BUFFER_SIZE object dirs, e.g. build/mandatory_bs$(BUFFER_SIZE)/get_next_line.o, with a pattern rule creating the dir.

Give each target its own OBJ list pointing to its own OBJDIR.

Guard bonus targets: only build them if get_next_line_bonus.c and get_next_line_utils_bonus.c exist (use wildcard checks), otherwise skip or print a message.

Clean between configs: make fclean before switching BUFFER_SIZE or target.

---
# Please take notice of the error I had that now is corrected
```bash
❯ make m -j6
Already up to date.
[Mandatory]
/usr/bin/ld: error in get_next_line.o(.eh_frame); no .eh_frame_hdr table will be created
/usr/bin/ld: error in get_next_line.o(.eh_frame); no .eh_frame_hdr table will be created
/usr/bin/ld: /tmp/gnl-f0f7f3.o: in function `gnl(int, char const*)':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/utils/gnl.cpp:20: undefined reference to `get_next_line'
/usr/bin/ld: get_next_line.o: in function `append_from_buffer':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:47: undefined reference to `'
/usr/bin/ld: get_next_line.o: in function `gnl_refill':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:65: undefined reference to `����'
/usr/bin/ld: get_next_line.o: in function `get_next_line':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:122: undefined reference to `��������'
/usr/bin/ld: /sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:128: undefined reference to `��������'
/usr/bin/ld: /sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:132: undefined reference to `���'
/usr/bin/ld: /tmp/gnl-e23584.o: in function `gnl(int, char const*)':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/utils/gnl.cpp:20: undefined reference to `get_next_line'
/usr/bin/ld: error in get_next_line.o(.eh_frame); no .eh_frame_hdr table will be created
/usr/bin/ld: /usr/bin/ld: get_next_line.o: in function `append_from_buffer':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:47: undefined reference to `'
/usr/bin/ld: get_next_line.o: in function `gnl_refill':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:65: undefined reference to `����'
/usr/bin/ld: get_next_line.o: in function `get_next_line':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:122: undefined reference to `��������'
/usr/bin/ld: /sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:128: undefined reference to `��������'
/usr/bin/ld: /sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:132: undefined reference to `���'
/tmp/gnl-5999c6.o: in function `gnl(int, char const*)':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/utils/gnl.cpp:20: undefined reference to `get_next_line'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
/usr/bin/ld: get_next_line.o: in function `append_from_buffer':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:47: undefined reference to `'
/usr/bin/ld: get_next_line.o: in function `gnl_refill':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:65: undefined reference to `����'
/usr/bin/ld: get_next_line.o: in function `get_next_line':
/sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:122: undefined reference to `��������'
/usr/bin/ld: /sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:128: undefined reference to `��������'
/usr/bin/ld: /sgoinfre/students/dlesieur/dlesieur/reviews/Examen42/Exam_Rank_03/laboratory/all_gnl/get_next_line/easy_get_next_line/training/gnlTester/../get_next_line.c:132: undefined reference to `���'
make: *** [Makefile:45: 42mandatory] Error 1
make: *** Waiting for unfinished jobs....
clang: error: linker command failed with exit code 1 (use -v to see invocation)
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [Makefile:42: 1mandatory] Error 1
make: *** [Makefile:48: 10Mmandatory] Error 1
```